### PR TITLE
Fix: set opacity to mobile page modal

### DIFF
--- a/packages/p2p/src/components/my-profile/my-profile.scss
+++ b/packages/p2p/src/components/my-profile/my-profile.scss
@@ -7,6 +7,10 @@
         @include mobile {
             padding: 1.6rem;
             width: 100vw;
+
+            .dc-mobile-full-page-modal {
+                opacity: 1 !important;
+            }
         }
     }
 


### PR DESCRIPTION
The problem is in mobile full page modal component, since it uses fade wrapper, when user closes another modal on the page, it adds inline opacity permanently to 0, causing it to never show payment methods again