### PR TITLE
57264, 57268, 57280 cards fixes

### DIFF
--- a/packages/p2p/src/components/my-profile/my-profile-separator-container/my-profile-separator-container.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-separator-container/my-profile-separator-container.scss
@@ -14,6 +14,10 @@
         height: 1px;
         margin: 0 1.6rem;
 
+        @include mobile {
+            margin: unset;
+        }
+
         &--invisible {
             background-color: inherit;
         }

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-balance/my-profile-balance.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-balance/my-profile-balance.scss
@@ -1,4 +1,8 @@
 .my-profile-balance {
+    @include mobile {
+        margin-bottom: 1.6rem;
+    }
+
     &__amount {
         margin-right: 0.8rem;
     }

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-container/my-profile-details-container.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-container/my-profile-details-container.scss
@@ -6,11 +6,17 @@
 
     @include mobile {
         border: unset;
-        padding: unset;
+        margin-bottom: 2.4rem;
+        margin-top: 1.6rem;
+        padding: 0 1.6rem;
     }
 
     &--table {
         display: flex;
         justify-content: space-between;
+
+        @include mobile {
+            display: unset;
+        }
     }
 }

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-table/my-profile-details-table.jsx
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-table/my-profile-details-table.jsx
@@ -3,12 +3,85 @@ import { Money, Table, Text } from '@deriv/components';
 import { useStores } from 'Stores';
 import { Localize } from 'Components/i18next';
 import { observer } from 'mobx-react-lite';
+import { isMobile } from '@deriv/shared';
 
 const MyProfileDetailsTable = () => {
     const { general_store, my_profile_store } = useStores();
 
     const { daily_buy, daily_buy_limit, daily_sell, daily_sell_limit } = my_profile_store.advertiser_info;
 
+    if (isMobile()) {
+        return (
+            <div className='my-profile-details-table'>
+                <Table className='my-profile-details-table-mobile'>
+                    <Table.Head>
+                        <Text color='prominent' size='xxxs'>
+                            <Localize i18n_default_text='Buy' />
+                        </Text>
+                    </Table.Head>
+                    <Table.Row className='my-profile-details-table--row'>
+                        <Table.Cell className='my-profile-details-table--cell'>
+                            <Text color='less-prominent' size='xxxs'>
+                                <Localize i18n_default_text='Daily limit' />
+                            </Text>
+                            <Text color='prominent' size='xs' weight='bold'>
+                                <Money
+                                    amount={daily_buy_limit}
+                                    currency={general_store.client.currency}
+                                    show_currency
+                                />
+                            </Text>
+                        </Table.Cell>
+                        <Table.Cell className='my-profile-details-table--cell'>
+                            <Text color='less-prominent' size='xxxs'>
+                                <Localize i18n_default_text='Available' />
+                            </Text>
+                            <Text color='prominent' size='xs' weight='bold'>
+                                <Money
+                                    amount={`${daily_buy_limit - daily_buy}`}
+                                    currency={general_store.client.currency}
+                                    show_currency
+                                />
+                            </Text>
+                        </Table.Cell>
+                    </Table.Row>
+                </Table>
+                <Table className='my-profile-details-table-mobile'>
+                    <Table.Head>
+                        <Text color='prominent' size='xxxs'>
+                            <Localize i18n_default_text='Sell' />
+                        </Text>
+                    </Table.Head>
+                    <Table.Row className='my-profile-details-table--row'>
+                        <Table.Cell className='my-profile-details-table--cell'>
+                            <Text color='less-prominent' size='xxxs'>
+                                <Localize i18n_default_text='Daily limit' />
+                            </Text>
+                            <Text color='prominent' size='xs' weight='bold'>
+                                <Money
+                                    amount={daily_sell_limit}
+                                    currency={general_store.client.currency}
+                                    show_currency
+                                />
+                            </Text>
+                        </Table.Cell>
+                        <Table.Cell className='my-profile-details-table--cell'>
+                            <Text color='less-prominent' size='xxxs'>
+                                <Localize i18n_default_text='Available' />
+                            </Text>
+                            <Text color='prominent' size='xs' weight='bold'>
+                                <Money
+                                    amount={`${daily_sell_limit - daily_sell}`}
+                                    currency={general_store.client.currency}
+                                    show_currency
+                                />
+                            </Text>
+                        </Table.Cell>
+                    </Table.Row>
+                </Table>
+            </div>
+        );
+    }
     return (
         <div className='my-profile-details-table'>
             <Table>

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-table/my-profile-details-table.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-details-table/my-profile-details-table.scss
@@ -14,6 +14,7 @@
 
         @include mobile {
             border-right: unset;
+            margin-top: 0.8rem;
         }
 
         &:nth-child(2) {
@@ -35,6 +36,16 @@
         @include mobile {
             flex-direction: column;
             width: unset;
+        }
+    }
+
+    &-mobile {
+        border-right: 1px solid var(--general-section-2);
+        margin-right: 1.6rem;
+        min-width: 52%;
+
+        &:nth-child(2) {
+            border-right: unset;
         }
     }
 }

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-name/my-profile-name.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-name/my-profile-name.scss
@@ -5,11 +5,16 @@
     width: 100%;
 
     @include mobile {
+        align-items: flex-start;
         margin: 0 0 2.4rem;
     }
 
     &__avatar {
         margin-right: 0.8rem;
+
+        @include mobile {
+            margin-right: 1.6rem;
+        }
     }
 
     &--column {
@@ -18,7 +23,10 @@
     }
 
     &__name {
-        width: 100%;
+        width: 90%;
+        @include mobile {
+            width: unset;
+        }
     }
 
     &--privacy {

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-privacy/my-profile-privacy.scss
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-privacy/my-profile-privacy.scss
@@ -6,7 +6,8 @@
 
     @include mobile {
         justify-content: space-between;
-        margin-bottom: 1.4rem;
+        margin: 1.4rem 0;
+        padding: 0 1.6rem;
     }
 
     &__toggle {
@@ -21,6 +22,7 @@
 
             @include mobile {
                 align-items: unset;
+                margin: unset;
             }
         }
 
@@ -33,11 +35,23 @@
             &--active {
                 left: calc(100% - 4px) !important;
             }
+
+            @include mobile {
+                top: 3px;
+                width: 18px;
+                height: 18px;
+            }
         }
 
         margin-right: 1.6rem;
         width: 32px;
         height: 17px;
+
+        @include mobile {
+            width: 45px;
+            height: 24px;
+            margin-right: unset;
+        }
     }
 }
 

--- a/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-stats-table/my-profile-stats-table.jsx
+++ b/packages/p2p/src/components/my-profile/my-profile-stats/my-profile-stats-table/my-profile-stats-table.jsx
@@ -40,67 +40,9 @@ const MyProfileStatsTable = () => {
                                 />
                             </Text>
                             <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {buy_completion_rate ? `${buy_completion_rate} (${buy_orders_count})` : '-'}
+                                {buy_completion_rate ? `${buy_completion_rate}% (${buy_orders_count})` : '0% (0)'}
                             </Text>
                         </Table.Cell>
-                        <Table.Cell className='my-profile-stats-table__cell'>
-                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
-                                <Localize
-                                    i18n_default_text='Sell Completion  <0>30d</0>'
-                                    components={[
-                                        <Text
-                                            key={0}
-                                            className='my-profile-stats-table--italic'
-                                            color='less-prominent'
-                                            size='xxxs'
-                                        />,
-                                    ]}
-                                />
-                            </Text>
-                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {sell_completion_rate ? `${sell_completion_rate} (${sell_orders_count})` : '-'}
-                            </Text>
-                        </Table.Cell>
-                    </Table.Row>
-                    <Table.Row className='my-profile-stats-table--mobile'>
-                        <Table.Cell className='my-profile-stats-table__cell'>
-                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
-                                <Localize
-                                    i18n_default_text='Buy Completion  <0>30d</0>'
-                                    components={[
-                                        <Text
-                                            key={0}
-                                            className='my-profile-stats-table--italic'
-                                            color='less-prominent'
-                                            size='xxxs'
-                                        />,
-                                    ]}
-                                />
-                            </Text>
-                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {buy_completion_rate ? `${buy_completion_rate} (${buy_orders_count})` : '-'}
-                            </Text>
-                        </Table.Cell>
-                        <Table.Cell className='my-profile-stats-table__cell'>
-                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
-                                <Localize
-                                    i18n_default_text='Sell Completion  <0>30d</0>'
-                                    components={[
-                                        <Text
-                                            key={0}
-                                            className='my-profile-stats-table--italic'
-                                            color='less-prominent'
-                                            size='xxxs'
-                                        />,
-                                    ]}
-                                />
-                            </Text>
-                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {sell_completion_rate ? `${sell_completion_rate} (${sell_orders_count})` : '-'}
-                            </Text>
-                        </Table.Cell>
-                    </Table.Row>
-                    <Table.Row className='my-profile-stats-table--mobile'>
                         <Table.Cell className='my-profile-stats-table__cell'>
                             <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
                                 <Localize
@@ -116,7 +58,27 @@ const MyProfileStatsTable = () => {
                                 />
                             </Text>
                             <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {buy_time_avg ? `${buy_time_avg} min` : '-'}
+                                {buy_time_avg ? `${buy_time_avg} min` : '00 min'}
+                            </Text>
+                        </Table.Cell>
+                    </Table.Row>
+                    <Table.Row className='my-profile-stats-table--mobile'>
+                        <Table.Cell className='my-profile-stats-table__cell'>
+                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
+                                <Localize
+                                    i18n_default_text='Sell Completion  <0>30d</0>'
+                                    components={[
+                                        <Text
+                                            key={0}
+                                            className='my-profile-stats-table--italic'
+                                            color='less-prominent'
+                                            size='xxxs'
+                                        />,
+                                    ]}
+                                />
+                            </Text>
+                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
+                                {sell_completion_rate ? `${sell_completion_rate}% (${sell_orders_count})` : '0% (0)'}
                             </Text>
                         </Table.Cell>
                         <Table.Cell className='my-profile-stats-table__cell'>
@@ -134,7 +96,7 @@ const MyProfileStatsTable = () => {
                                 />
                             </Text>
                             <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {release_time_avg ? `${release_time_avg} min` : '-'}
+                                {release_time_avg ? `${release_time_avg} min` : '00 min'}
                             </Text>
                         </Table.Cell>
                     </Table.Row>
@@ -167,10 +129,20 @@ const MyProfileStatsTable = () => {
                                         show_currency
                                     />
                                 ) : (
-                                    '-'
+                                    <Money amount={0.00} currency={general_store.client.currency} show_currency />
                                 )}
                             </Text>
                         </Table.Cell>
+                        <Table.Cell className='my-profile-stats-table__cell'>
+                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
+                                <Localize i18n_default_text='Trade partners' />
+                            </Text>
+                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
+                                {partner_count || '0'}
+                            </Text>
+                        </Table.Cell>
+                    </Table.Row>
+                    <Table.Row className='my-profile-stats-table--mobile'>
                         <Table.Cell className='my-profile-stats-table__cell'>
                             <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
                                 <Localize
@@ -193,16 +165,6 @@ const MyProfileStatsTable = () => {
                             </Text>
                             <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
                                 {total_orders_count || '0'}
-                            </Text>
-                        </Table.Cell>
-                    </Table.Row>
-                    <Table.Row className='my-profile-stats-table--mobile'>
-                        <Table.Cell className='my-profile-stats-table__cell'>
-                            <Text as='p' color='less-prominent' line_height='m' size='xxxs'>
-                                <Localize i18n_default_text='Trade partners' />
-                            </Text>
-                            <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                                {partner_count || '0'}
                             </Text>
                         </Table.Cell>
                     </Table.Row>
@@ -230,7 +192,7 @@ const MyProfileStatsTable = () => {
                             />
                         </Text>
                         <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                            {buy_completion_rate ? `${buy_completion_rate}% (${buy_orders_count})` : '-'}
+                            {buy_completion_rate ? `${buy_completion_rate}% (${buy_orders_count})` : '0% (0)'}
                         </Text>
                     </Table.Cell>
                     <Table.Cell className='my-profile-stats-table__cell'>
@@ -248,7 +210,7 @@ const MyProfileStatsTable = () => {
                             />
                         </Text>
                         <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                            {sell_completion_rate ? `${sell_completion_rate}% (${sell_orders_count})` : '-'}
+                            {sell_completion_rate ? `${sell_completion_rate}% (${sell_orders_count})` : '0% (0)'}
                         </Text>
                     </Table.Cell>
                     <Table.Cell className='my-profile-stats-table__cell'>
@@ -266,7 +228,7 @@ const MyProfileStatsTable = () => {
                             />
                         </Text>
                         <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                            {buy_time_avg ? `${buy_time_avg} min` : '-'}
+                            {buy_time_avg ? `${buy_time_avg} min` : '00 min'}
                         </Text>
                     </Table.Cell>
                     <Table.Cell className='my-profile-stats-table__cell'>
@@ -284,7 +246,7 @@ const MyProfileStatsTable = () => {
                             />
                         </Text>
                         <Text as='p' color='prominent' line_height='m' size='xs' weight='bold'>
-                            {release_time_avg ? `${release_time_avg} min` : '-'}
+                            {release_time_avg ? `${release_time_avg} min` : '00 min'}
                         </Text>
                     </Table.Cell>
                 </Table.Row>
@@ -315,7 +277,7 @@ const MyProfileStatsTable = () => {
                             {total_turnover ? (
                                 <Money amount={total_turnover} currency={general_store.client.currency} show_currency />
                             ) : (
-                                '-'
+                                <Money amount={0.00} currency={general_store.client.currency} show_currency />
                             )}
                         </Text>
                     </Table.Cell>

--- a/packages/p2p/src/components/my-profile/my-profile.scss
+++ b/packages/p2p/src/components/my-profile/my-profile.scss
@@ -1,8 +1,17 @@
 .my-profile {
     &__content {
         @include mobile {
-            padding: 1.6rem;
+            padding-top: 0;
             width: 100vw;
         }
+    }
+
+    &__navigation {
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        margin: 2.3rem 0;
+        padding: 0 1.6rem;
     }
 }

--- a/packages/p2p/src/components/trade-badge/trade-badge.jsx
+++ b/packages/p2p/src/components/trade-badge/trade-badge.jsx
@@ -5,23 +5,21 @@ import { Text } from '@deriv/components';
 import { localize, Localize } from 'Components/i18next';
 
 const TradeBadge = ({ is_poa_verified = false, is_poi_verified = false, large = false, trade_count }) => {
-    if (trade_count < 100) {
-        return null;
-    }
-
     return (
         <React.Fragment>
-            <div
-                className={classNames('trade-badge', {
-                    'trade-badge--large': large,
-                    'trade-badge--gold': trade_count >= 100 && trade_count < 250,
-                    'trade-badge--green': trade_count >= 250,
-                })}
-            >
-                <Text color='colored-background' size='xxxs'>
-                    {`${trade_count >= 250 ? '250+' : '100+'} ${large ? localize('trades') : ''}`}
-                </Text>
-            </div>
+            {trade_count > 100 ? (
+                <div
+                    className={classNames('trade-badge', {
+                        'trade-badge--large': large,
+                        'trade-badge--gold': trade_count >= 100 && trade_count < 250,
+                        'trade-badge--green': trade_count >= 250,
+                    })}
+                >
+                    <Text color='colored-background' size='xxxs'>
+                        {`${trade_count >= 250 ? '250+' : '100+'} ${large ? localize('trades') : ''}`}
+                    </Text>
+                </div>
+            ) : null}
             {is_poi_verified ? (
                 <div
                     className={classNames('trade-badge', {

--- a/packages/shared/src/styles/themes.scss
+++ b/packages/shared/src/styles/themes.scss
@@ -260,6 +260,9 @@
         --gradient-danger: #{$gradient-color-red-2};
         --contract-gradient-danger: #{$contract-gradient-color-red-2};
         --gradient-right-edge: #{$gradient-color-black};
+        --gradient-blue: #{$gradient-color-blue-5};
+        --gradient-gold: #{$gradient-color-gold};
+        --gradient-green: #{$gradient-color-green-4};
         // Badge
         --badge-white: #{$color-white};
         --badge-blue: #{$color-blue-4};


### PR DESCRIPTION
My Profile responsive design differences are fixed.

Stats and Rating responsive details displaying correct labels and placements.

New Accounts or not traded account by default is showing as 0 instead of - units.

Trade badge is showed properly in light and dark mode